### PR TITLE
Add missing example to Makefile and update links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-C library implementation of CFA-Conventions v0.6
-https://github.com/davidhassell/cfa-conventions/blob/stand-alone/source/cfa.md
+C library implementation of
+[CFA-Conventions v0.6](https://github.com/NCAS-CMS/cfa-conventions/blob/master/source/cfa.md)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -1,7 +1,7 @@
 example%.nc: example%.cdl
 	ncgen -4 $<
 
-all: example1.nc example2.nc example3.nc example4.nc example5.nc example6.nc example7.nc
+all: example1.nc example2.nc example3.nc example4.nc example5.nc example6.nc example7.nc example8.nc
 
 clean:
 	rm *.nc

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,5 +1,6 @@
-This directory (CFA/examples) contains the example from the CFA 0.6 document
-(include link to document here), in CDL format.  
+This directory (CFA-C/examples) contains the examples from the
+[CFA 0.6 document](https://github.com/NCAS-CMS/cfa-conventions/blob/master/source/cfa.md),
+in CDL format.
 
 They can be converted to valid netCDF4 by running the command:
 
@@ -11,4 +12,4 @@ There is also a Makefile.  Individual examples can be converted using:
 
 Or, to make all the examples:
 
-   make
+    make


### PR DESCRIPTION
Hi Neil (when you return from your holiday/leave, which I appreciate won't be for a good month or so from now!), I was working through the examples here yesterday for my understanding and noticed a few things that could do with being updated, namely:

* `examples/Makefile` listed all but one example file in that directory, so `make` didn't run `ncgen` on the final (eighth) one; and
* there is one missing link to the CFA-Conventions v0.6 in the READMEs and the one that is referenced in the root README points to David's copy which is no longer the canonical repository (I believe) since we have created a copy under `NCAS-CMS`.

It is easier to indicate and update the Makefile and the links accordingly via PR so I've went ahead and put this up. Just let me know if you disagree with anything or if any changes are required. Thanks.